### PR TITLE
Fix dark mode "on"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,7 +79,7 @@
 {/if}
 
 {#key [useDarkMode, theme]}
-    <div class:ios-lightmode={!useDarkMode && theme === 'ios'} class:safe-areas={!ignoreSafeAreaPages.includes($currentPageStore)} style:background-color={safeAreaPaddingColor}>
+    <div class:dark={useDarkMode} class:ios-lightmode={!useDarkMode && theme === 'ios'} class:safe-areas={!ignoreSafeAreaPages.includes($currentPageStore)} style:background-color={safeAreaPaddingColor}>
         <App {theme} safeAreas={false} dark={useDarkMode}>
             <Page>
                 {#if $currentPageStore === 'main'}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const konstaConfig = require('konsta/config');
 
 module.exports = konstaConfig({
+  darkMode: 'class',
   konsta: {
 
   }});


### PR DESCRIPTION
Fix broken dark mode "on".

Before this PR "on" behaves the same as "System".
This PR ensures that the theme is always dark with "on" even when the system theme is light.

Tested on Web and Android.

Before:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/b7d0c9cb-b9a5-48ab-a8ed-8e908b5fc8c8" />


After:
<img height="400" alt="image" src="https://github.com/user-attachments/assets/5fd924f1-2ac0-47da-8897-2dd140dcb08f" />


## Acceptance
- Firefox on Windows 11
- Android 16 on Google Pixel 8