### PR TITLE
Title: Fix vehicle markers not updating on realtime data change

### DIFF
--- a/src/lib/components/pages/Main/Map.svelte
+++ b/src/lib/components/pages/Main/Map.svelte
@@ -245,10 +245,14 @@
         new LocateControl({keepCurrentZoomLevel: true, showPopup: false, locateOptions: {watch: true}, onLocationError: function() {}}).addTo(map).start();
 
         // Event handlers
-        realtimeGtfsDataStore.subscribe(function(value) {updateMarkers()});
         map.addEventListener("zoomend", onMapInteraction);
         map.addEventListener("moveend", onMapInteraction);
     });
+
+    // Update markers on data change
+    $: if (map && $realtimeGtfsDataStore) {
+        updateMarkers();
+    }
 </script>
 
 <style>


### PR DESCRIPTION
This PR fixes a bug where vehicle markers remained static on the map even when the underlying `realtimeGtfsDataStore` updated (every 10s). Previously, markers would only update their positions if the user manually panned or zoomed the map.

The issue was caused by a race condition in the manual store subscription inside onMount:

```JavaScript
realtimeGtfsDataStore.subscribe(function(value) { updateMarkers() });
```

This listener was firing before Svelte had propagated the new store value to the component's local `$realtimeGtfsDataStore`. Since `updateMarkers()` relies on `$realtimeGtfsDataStore` to draw vehicles, it was executing with stale data during the automatic fetch cycle.

I replaced the manual `.subscribe()` in `onMount` with a native Svelte reactive statement:

```JavaScript
$: if (map && $realtimeGtfsDataStore) {
    updateMarkers();
}
```

This guarantees that `updateMarkers()` runs only after the `$realtimeGtfsDataStore` variable has been updated with fresh data.

## Acceptance
- Firefox on Windows 11
- Android 16 on Google Pixel 8